### PR TITLE
feature #11 Make port number a choice at launch

### DIFF
--- a/CI/src/main/java/group1/Main.java
+++ b/CI/src/main/java/group1/Main.java
@@ -14,9 +14,14 @@ class Main
     // used to start the CI server in command line
     public static void main(String[] args) throws Exception
     {
-        Server server = new Server(8080);
+        int port = 8080; // default port
+        if (args.length > 0) {
+            port = Integer.parseInt(args[0]);
+        }
+        Server server = new Server(port);
         server.setHandler(new ContinuousIntegrationServer()); 
         server.start();
+        System.out.println("Listening on port " + port);
         server.join();
     }
 }


### PR DESCRIPTION
Closes #11 

This implements passing the port as a command line argument when starting the server.

To start the server with port 8001 run:

```
java -cp target/CI-1.0-SNAPSHOT-jar-with-dependencies.jar group1.Main 8001
```